### PR TITLE
Wrap AbstractDao calls in a transaction if using ThreadLocalSession

### DIFF
--- a/core/src/main/kotlin/com/github/andrewoma/kwery/core/ThreadLocalSession.kt
+++ b/core/src/main/kotlin/com/github/andrewoma/kwery/core/ThreadLocalSession.kt
@@ -52,8 +52,7 @@ class ThreadLocalSession(val dataSource: DataSource,
     }
 
     override val currentTransaction: Transaction?
-        get() = threadLocalSession.get()?.currentTransaction ?:
-                throw UnsupportedOperationException("'currentTransaction' is only supported within a transaction in ThreadLocalSession")
+        get() = threadLocalSession.get()?.currentTransaction
 
     override val connection: Connection
         get() = threadLocalSession.get()?.connection ?:

--- a/mapper/src/main/kotlin/com/github/andrewoma/kwery/mapper/AbstractDao.kt
+++ b/mapper/src/main/kotlin/com/github/andrewoma/kwery/mapper/AbstractDao.kt
@@ -80,7 +80,7 @@ abstract class AbstractDao<T : Any, ID : Any>(
     }
 
     protected fun Iterable<Column<T, *>>.equate(separator: String = ", ", f: (Column<T, *>) -> String = nf): String {
-        return this.map { "${f(it)} = :${f(it)}" }.joinToString(separator)
+        return this.map { "${f(it) } = :${f(it)}" }.joinToString(separator)
     }
 
     protected fun Collection<ID>.copyToSqlArray(): java.sql.Array {
@@ -333,7 +333,6 @@ abstract class AbstractDao<T : Any, ID : Any>(
             values.map { id(it) to it }.toMap()
         }
     }
-
 
     private fun freeIfSupported(array: Array) {
         try {


### PR DESCRIPTION
- Wrapped all of the Dao interface methods in AbstractDao with a transaction when using a ThreadLocalSession
- ThreadLocalSession.currentTransaction getter changed to return null rather than throw UnsupportedOperationException. 

Thanks for the guidance @andrewoma.
