### PR TITLE
We cound`t use letter after using a number in the bind parameters. 

### DIFF
--- a/core/src/main/kotlin/com/github/andrewoma/kwery/core/BoundQuery.kt
+++ b/core/src/main/kotlin/com/github/andrewoma/kwery/core/BoundQuery.kt
@@ -37,7 +37,7 @@ internal fun BoundQuery(query: String, inClauseSizes: Map<String, Int>): BoundQu
 }
 
 internal inline fun replaceBindings(query: String, onBinding: (String) -> String): String {
-    val pattern = Pattern.compile("""\:([a-zA-Z_]+[0-9]*)""")
+    val pattern = Pattern.compile("""\:(([a-zA-Z_]+[0-9]*)+)""")
     val matcher = pattern.matcher(query)
 
     val result = StringBuffer()


### PR DESCRIPTION
We cound`t use letter after using a number in the bind parameters. Exemple b2b would resolve to b2 instead of b2b. Now we can use something like this b2b2c and it'll work.