### PR TITLE
added Table.mapMapper support

### DIFF
--- a/mapper/src/main/kotlin/com/github/andrewoma/kwery/mapper/Column.kt
+++ b/mapper/src/main/kotlin/com/github/andrewoma/kwery/mapper/Column.kt
@@ -48,7 +48,13 @@ data class Column<C, T>(
         /**
          * True if the column is nullable
          */
-        val isNullable: Boolean
+        val isNullable: Boolean,
+
+        /**
+         * A converter which will be used in [Table.mapMapper]
+         * default value is set to maintain source compatibility with possible constructor invocations
+         */
+        val mapConverter: (String) -> T = NoMapConverter
 ) {
     /**
      * A type-safe variant of `to`
@@ -64,4 +70,10 @@ data class Column<C, T>(
     override fun toString(): String {
         return "Column($name id=$id version=$version nullable=$isNullable)" // Prevent NPE in debugger on "property"
     }
+
+    companion object {
+        val NoMapConverter: (String) -> Nothing =
+                { throw UnsupportedOperationException("there's no mapConverter on this column") }
+    }
+
 }

--- a/mapper/src/test/kotlin/com/github/andrewoma/kwery/mappertest/MapMapperTest.kt
+++ b/mapper/src/test/kotlin/com/github/andrewoma/kwery/mappertest/MapMapperTest.kt
@@ -1,0 +1,67 @@
+package com.github.andrewoma.kwery.mappertest
+
+import com.github.andrewoma.kwery.mapper.Column
+import com.github.andrewoma.kwery.mapper.SimpleConverter
+import com.github.andrewoma.kwery.mapper.Table
+import com.github.andrewoma.kwery.mapper.Value
+import org.junit.Test
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.*
+import kotlin.test.assertEquals
+
+class MapMapperTest {
+
+    @Test
+    fun testMapMapping() {
+        val id = UUID.randomUUID()
+        val now = LocalDateTime.now()
+        val something = mapOf(
+                "id" to id.toString(),
+                "name" to "Whatever",
+                "lastUpdated" to now.format(DateTimeFormatter.ISO_DATE_TIME)!!
+        )
+
+        val mapped = someTable.mapMapper()(something)
+
+        assertEquals(id, mapped.id)
+        assertEquals("Whatever", mapped.name)
+        assertEquals(now, mapped.lastUpdated)
+    }
+
+    class Something(
+            val id: UUID,
+            val name: String,
+            val lastUpdated: LocalDateTime
+    )
+
+    object someTable : Table<Something, UUID>(" won't ever be used ") {
+
+        val Id
+                by col(Something::id, name = "id", id = true, default = DefaultUuid, converter = UuidConverter, mapConverter = UUID::fromString)
+
+        val Name
+                by col(Something::name, name = "name", mapConverter = { it })
+
+        val LastUpdated
+                by col(Something::lastUpdated, name = "lastUpdated", mapConverter = { LocalDateTime.parse(it, DateTimeFormatter.ISO_DATE_TIME) })
+
+
+        override fun idColumns(id: UUID): Set<Pair<Column<Something, *>, *>> =
+                setOf(Id of id)
+
+        override fun create(value: Value<Something>): Something = Something(
+                value of Id,
+                value of Name,
+                value of LastUpdated
+        )
+
+    }
+
+}
+
+private val DefaultUuid = UUID(0, 0)
+
+object UuidConverter : SimpleConverter<UUID>(
+        { row, name -> row.obj(name) as UUID }
+)

--- a/mapper/src/test/kotlin/com/github/andrewoma/kwery/mappertest/issues/Issue11_12.kt
+++ b/mapper/src/test/kotlin/com/github/andrewoma/kwery/mappertest/issues/Issue11_12.kt
@@ -14,7 +14,8 @@ class Issue11_12 {
         val emailColumn = Column(
                 User::email, null,
                 optional(stringConverter),
-                "email", false, false, true, false
+                "email", false, false, true, false,
+                Column.NoMapConverter
         )
 
         usersTable.addColumn(emailColumn)


### PR DESCRIPTION
Added `mapMapper()` function to `Table` class.
This is useful when you want to convert `Map<String, String>` (e. g. filled web-form) into an object, and helps to reuse `create(Value<T>)` function for this case.

If this implementation is too specific, I'll be glad to see and implemeny any suggestions on how to make it more general-purpose.