### PR TITLE
Escaping column and table names by Dialect

### DIFF
--- a/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/Dialect.kt
+++ b/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/Dialect.kt
@@ -55,6 +55,8 @@ interface Dialect {
                 .joinToString(" ")
         return sql + "\n" + limitAndOffset
     }
+
+    fun escapeColumnName(columnName: String): String = columnName
 }
 
 internal fun String.truncate(limit: Int): String {

--- a/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/Dialect.kt
+++ b/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/Dialect.kt
@@ -56,7 +56,7 @@ interface Dialect {
         return sql + "\n" + limitAndOffset
     }
 
-    fun escapeColumnName(columnName: String): String = columnName
+    fun escapeName(columnName: String): String = columnName
 }
 
 internal fun String.truncate(limit: Int): String {

--- a/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/MysqlDialect.kt
+++ b/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/MysqlDialect.kt
@@ -48,7 +48,7 @@ open class MysqlDialect : Dialect {
 
     override val supportsFetchingGeneratedKeysByName = false
 
-    override fun escapeColumnName(columnName: String): String =
+    override fun escapeName(columnName: String): String =
             '`' + columnName.replace("`", "``") + '`'
 
 }

--- a/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/MysqlDialect.kt
+++ b/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/MysqlDialect.kt
@@ -47,4 +47,8 @@ open class MysqlDialect : Dialect {
     override fun allocateIds(count: Int, sequence: String, columnName: String) = throw UnsupportedOperationException()
 
     override val supportsFetchingGeneratedKeysByName = false
+
+    override fun escapeColumnName(columnName: String): String =
+            '`' + columnName.replace("`", "``") + '`'
+
 }

--- a/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/PostgresDialect.kt
+++ b/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/PostgresDialect.kt
@@ -49,4 +49,8 @@ open class PostgresDialect : Dialect {
             "select nextval('$sequence') as $columnName from generate_series(1, $count)"
 
     override val supportsFetchingGeneratedKeysByName = true
+
+    override fun escapeColumnName(columnName: String): String =
+            '"' + columnName.replace("\"", "\"\"") + '"'
+
 }

--- a/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/PostgresDialect.kt
+++ b/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/PostgresDialect.kt
@@ -50,7 +50,7 @@ open class PostgresDialect : Dialect {
 
     override val supportsFetchingGeneratedKeysByName = true
 
-    override fun escapeColumnName(columnName: String): String =
+    override fun escapeName(columnName: String): String =
             '"' + columnName.replace("\"", "\"\"") + '"'
 
 }

--- a/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/SqliteDialect.kt
+++ b/core/src/main/kotlin/com/github/andrewoma/kwery/core/dialect/SqliteDialect.kt
@@ -47,4 +47,8 @@ open class SqliteDialect : Dialect {
     override fun allocateIds(count: Int, sequence: String, columnName: String) = throw UnsupportedOperationException()
 
     override val supportsFetchingGeneratedKeysByName = false
+
+    override fun escapeName(columnName: String): String =
+            '"' + columnName.replace("\"", "\"\"") + '"'
+
 }

--- a/mapper/src/main/kotlin/com/github/andrewoma/kwery/mapper/AbstractDao.kt
+++ b/mapper/src/main/kotlin/com/github/andrewoma/kwery/mapper/AbstractDao.kt
@@ -76,11 +76,11 @@ abstract class AbstractDao<T : Any, ID : Any>(
     }
 
     protected fun Iterable<Column<T, *>>.join(separator: String = ", ", f: (Column<T, *>) -> String = nf): String {
-        return this.map { f(it) }.joinToString(separator)
+        return this.map { session.dialect.escapeColumnName(f(it)) }.joinToString(separator)
     }
 
     protected fun Iterable<Column<T, *>>.equate(separator: String = ", ", f: (Column<T, *>) -> String = nf): String {
-        return this.map { "${f(it)} = :${f(it)}" }.joinToString(separator)
+        return this.map { "${session.dialect.escapeColumnName(f(it))} = :${f(it)}" }.joinToString(separator)
     }
 
     protected fun Collection<ID>.copyToSqlArray(): java.sql.Array {

--- a/mapper/src/main/kotlin/com/github/andrewoma/kwery/mapper/AbstractDao.kt
+++ b/mapper/src/main/kotlin/com/github/andrewoma/kwery/mapper/AbstractDao.kt
@@ -80,7 +80,7 @@ abstract class AbstractDao<T : Any, ID : Any>(
     }
 
     protected fun Iterable<Column<T, *>>.joinStrings(separator: String = ", ", f: (Column<T, *>) -> String = nf): String {
-        return this.joinToString(separator) { session.dialect.escapeName(f(it)) }
+        return this.joinToString(separator) { f(it) }
     }
 
     protected fun Iterable<Column<T, *>>.equate(separator: String = ", ", f: (Column<T, *>) -> String = nf): String {


### PR DESCRIPTION
Escaping column names in SQL queries created by kwery-mapper. Should fix #19.